### PR TITLE
add curseforge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,4 +40,6 @@ Links
 
 [Curse Page](http://wow.curse.com/downloads/wow-addons/details/rocku.aspx)
 
+[Curseforge Page](https://wow.curseforge.com/addons/rocku/)
+
 [Reforged Guild](http://reforged.net) \-Late-night raids on Runetotem US 


### PR DESCRIPTION
adds link to curseforge page while project is downrev from current game version and won't show up on normal curse page
